### PR TITLE
socket++-1.12.13

### DIFF
--- a/socket++/README
+++ b/socket++/README
@@ -4,22 +4,22 @@ Socket++ library defines a family of C++ classes that can be used more
 effectively than directly calling the underlying low-level system functions.
 
 Runtime requirements:
-  cygwin-3.6.3-1
-  libgcc1-12.4.0-3
-  libsocket++-devel-1.12.13-1bl3
-  libsocket++1-1.12.13-1bl3
-  libstdc++6-12.4.0-3
-  pkg-config-2.4.3-1
+  cygwin-3.6.10-1
+  libgcc1-14.4.0-1
+  libsocket++-devel-1.12.13-1bl4
+  libsocket++1-1.12.13-1bl4
+  libstdc++6-14.4.0-1
+  pkg-config-3.0.5-1
 
 Build requirements:
 (besides corresponding -devel packages)
-  autoconf-15-2
+  autoconf-15-3
   automake-20250528-1
-  binutils-2.44-1
-  cygport-0.36.9-1
-  gcc-core-12.4.0-3
-  gcc-g++-12.4.0-3
-  libtool-2.5.4-1
+  binutils-2.47-1
+  cygport-0.37.7-1
+  gcc-core-14.4.0-1
+  gcc-g++-14.4.0-1
+  libtool-2.6.2-1
   make-4.4.1-2
 
 Canonical website:
@@ -78,6 +78,9 @@ Files included in the binary package:
 ------------------
 
 Port Notes:
+
+----- version 1.12.13-1bl4 -----
+Rebuild with gcc-14.4.0-1
 
 ----- version 1.12.13-1bl3 -----
 Rebuild with gcc-12.4.0

--- a/socket++/socket++-1.12.13-1bl4.cygport
+++ b/socket++/socket++-1.12.13-1bl4.cygport
@@ -7,8 +7,8 @@ SUMMARY="C++ interface for sockets"
 DESCRIPTION="Socket++ library defines a family of C++ classes that can be used more
 effectively than directly calling the underlying low-level system functions."
 
-# LICENSE="Public Domain"
-# LICENSE_SPDX="SPDX-License-Identifier: "
+LICENSE="LicenseRef-socketxx"
+LICENSE_SPDX="SPDX-License-Identifier: LicenseRef-socketxx"
 LICENSE_URI="COPYING"
 
 inherit git

--- a/socket++/socket++-1.12.13-1bl4.src.patch
+++ b/socket++/socket++-1.12.13-1bl4.src.patch
@@ -1,12 +1,12 @@
---- origsrc/socketxx/Makefile.am	2025-06-09 23:27:09.000000000 +0900
-+++ src/socketxx/Makefile.am	2025-06-09 23:27:11.505127500 +0900
+--- origsrc/socketxx/Makefile.am	2026-08-18 19:41:21.000000000 +0000
++++ src/socketxx/Makefile.am	2026-08-18 19:41:23.457450400 +0000
 @@ -1,2 +1,4 @@
  SUBDIRS = socket++ doc
  
 +pkgconfigdir = $(libdir)/pkgconfig
 +pkgconfig_DATA = socket++.pc
---- origsrc/socketxx/configure.in	2025-06-09 23:27:09.000000000 +0900
-+++ src/socketxx/configure.in	2025-06-09 23:27:11.505127500 +0900
+--- origsrc/socketxx/configure.in	2026-08-18 19:41:21.000000000 +0000
++++ src/socketxx/configure.in	2026-08-18 19:41:23.458204000 +0000
 @@ -3,7 +3,7 @@ dnl Use autoheader on this file to produ
  dnl Then use configure script to generate makefile from Makefile.in
  
@@ -31,14 +31,14 @@
  dnl generate output files
 -AC_OUTPUT(Makefile socket++/Makefile doc/Makefile test/Makefile)
 +AC_OUTPUT(Makefile socket++/Makefile doc/Makefile test/Makefile socket++.pc)
---- origsrc/socketxx/doc/Makefile.am	2025-06-09 23:27:09.000000000 +0900
-+++ src/socketxx/doc/Makefile.am	2025-06-09 23:27:11.505127500 +0900
+--- origsrc/socketxx/doc/Makefile.am	2026-08-18 19:41:21.000000000 +0000
++++ src/socketxx/doc/Makefile.am	2026-08-18 19:41:23.460231200 +0000
 @@ -1,2 +1 @@
 -info_TEXINFOS = socket++.texi
 -
 +# info_TEXINFOS = socket++.texi
---- origsrc/socketxx/socket++/Makefile.am	2025-06-09 23:27:09.000000000 +0900
-+++ src/socketxx/socket++/Makefile.am	2025-06-09 23:27:11.505127500 +0900
+--- origsrc/socketxx/socket++/Makefile.am	2026-08-18 19:41:21.000000000 +0000
++++ src/socketxx/socket++/Makefile.am	2026-08-18 19:41:23.461485200 +0000
 @@ -24,6 +24,6 @@ libsocketinclude_HEADERS = \
  	smtp.h \
  	ftp.h \
@@ -47,8 +47,8 @@
 +libsocket___la_LDFLAGS = -no-undefined -version-info @LIBSOCKET_SO_VERSION@
  libsocket___la_LIBADD =
  
---- origsrc/socketxx/socket++/local.h	2025-06-09 23:27:09.000000000 +0900
-+++ src/socketxx/socket++/local.h	2025-06-09 23:27:11.505127500 +0900
+--- origsrc/socketxx/socket++/local.h	2026-08-18 19:41:21.000000000 +0000
++++ src/socketxx/socket++/local.h	2026-08-18 19:41:23.462258000 +0000
 @@ -89,12 +89,14 @@ extern "C" unsigned long inet_addr (cons
  // arpa/in.h does not provide a protype for the following
  extern "C" char* inet_ntoa (in_addr ina);
@@ -64,8 +64,8 @@
  
  #ifdef __osf__
    extern "C" {
---- origsrc/socketxx/socket++/sig.cpp	2025-06-09 23:27:09.000000000 +0900
-+++ src/socketxx/socket++/sig.cpp	2025-06-09 23:27:11.505127500 +0900
+--- origsrc/socketxx/socket++/sig.cpp	2026-08-18 19:41:21.000000000 +0000
++++ src/socketxx/socket++/sig.cpp	2026-08-18 19:41:23.463497800 +0000
 @@ -153,6 +153,7 @@ void sig::sysresume (int signo, bool set
      sa.sa_flags = 0;
    }
@@ -82,8 +82,8 @@
  }
  
  struct procsig {
---- origsrc/socketxx/socket++/sockstream.cpp	2025-06-09 23:27:09.000000000 +0900
-+++ src/socketxx/socket++/sockstream.cpp	2025-06-09 23:27:11.517149600 +0900
+--- origsrc/socketxx/socket++/sockstream.cpp	2026-08-18 19:41:21.000000000 +0000
++++ src/socketxx/socket++/sockstream.cpp	2026-08-18 19:41:23.464284000 +0000
 @@ -233,8 +233,10 @@ bool sockerr::benign () const
  // On FreeBSD (and probably on Linux too) 
  // EAGAIN has the same value as EWOULDBLOCK
@@ -130,8 +130,8 @@
        throw sockerr (errno, "sockbuf::closeonexec", sockname.c_str());
    }
  }
---- origsrc/socketxx/socket++/sockstream.h	2025-06-09 23:27:09.000000000 +0900
-+++ src/socketxx/socket++/sockstream.h	2025-06-09 23:27:11.517149600 +0900
+--- origsrc/socketxx/socket++/sockstream.h	2026-08-18 19:41:21.000000000 +0000
++++ src/socketxx/socket++/sockstream.h	2026-08-18 19:41:23.466312500 +0000
 @@ -138,8 +138,10 @@ public:
      msg_dontroute	= MSG_DONTROUTE,
  
@@ -143,8 +143,8 @@
    };
    enum shuthow {
      shut_read,
---- origsrc/socketxx/socket++.pc.in	1970-01-01 09:00:00.000000000 +0900
-+++ src/socketxx/socket++.pc.in	2025-06-09 23:27:11.517149600 +0900
+--- origsrc/socketxx/socket++.pc.in	1970-01-01 00:00:00.000000000 +0000
++++ src/socketxx/socket++.pc.in	2026-08-18 19:41:23.467524800 +0000
 @@ -0,0 +1,10 @@
 +prefix=@prefix@
 +exec_prefix=@exec_prefix@


### PR DESCRIPTION
Version `1.12.13`, but the build failed -- see the failure Issue and the run log below for what's wrong.

Push a fix directly onto this branch (`dorgann/socket++-1.12.13`), then re-run the build against it:
```
gh workflow run build-package.yml -f package=socket++ -f branch=dorgann/socket++-1.12.13 --repo fd00/dorgann
```

Run: https://github.com/fd00/dorgann/actions/runs/32177562361