### PR TITLE
libexttextcat-3.4.8

### DIFF
--- a/libexttextcat/README
+++ b/libexttextcat/README
@@ -4,43 +4,42 @@ Libexttextcat is an N-Gram-Based Text Categorization library primarily
 intended for language guessing.
 
 Runtime requirements:
-  cygwin-3.6.4-1
-  libexttextcat2.0-devel-3.4.7-1bl2
-  libexttextcat2.0_0-3.4.7-1bl2
-  pkg-config-2.5.1-1
+  cygwin-3.6.10-1
+  libexttextcat2.0-devel-3.4.8-1bl1
+  libexttextcat2.0_1-3.4.8-1bl1
+  pkg-config-3.0.5-1
 
 Build requirements:
 (besides corresponding -devel packages)
-  autoconf-15-2
+  autoconf-15-3
   automake-20250528-1
-  binutils-2.45-1
-  cygport-0.37.2-1
-  gcc-core-13.4.0-1
-  libtool-2.5.4-1
+  binutils-2.47-1
+  cygport-0.37.7-1
+  gcc-core-14.4.0-1
+  libtool-2.6.2-1
   make-4.4.1-2
-  vala-0.38.8-1
 
 Canonical website:
   https://wiki.documentfoundation.org/Libexttextcat
 
 Canonical download:
-  https://dev-www.libreoffice.org/src//libexttextcat-3.4.7.tar.xz
+  https://dev-www.libreoffice.org/src//libexttextcat-3.4.8.tar.xz
 
 -------------------------------------------
 
 Build instructions:
-  1. unpack libexttextcat-3.4.7-X-src.tar.xz
+  1. unpack libexttextcat-3.4.8-X-src.tar.xz
   2. if you use setup to install this src package,
      it will be unpacked under /usr/src automatically
         % cd /usr/src
-        % cygport ./libexttextcat-3.4.7-X.cygport all
+        % cygport ./libexttextcat-3.4.8-X.cygport all
 
 This will create:
-  /usr/src/libexttextcat-3.4.7-X-src.tar.xz
-  /usr/src/libexttextcat-3.4.7-X.tar.xz
-  /usr/src/libexttextcat2.0_0-3.4.7-X.tar.xz
-  /usr/src/libexttextcat2.0-devel-3.4.7-X.tar.xz
-  /usr/src/vala-libexttextcat-3.4.7-X.tar.xz
+  /usr/src/libexttextcat-3.4.8-X-src.tar.xz
+  /usr/src/libexttextcat-3.4.8-X.tar.xz
+  /usr/src/libexttextcat2.0_1-3.4.8-X.tar.xz
+  /usr/src/libexttextcat2.0-devel-3.4.8-X.tar.xz
+  /usr/src/vala-libexttextcat-3.4.8-X.tar.xz
 
 -------------------------------------------
 
@@ -104,6 +103,7 @@ Files included in the binary package:
   /usr/share/libexttextcat/fon.lm
   /usr/share/libexttextcat/fpdb.conf
   /usr/share/libexttextcat/fr.lm
+  /usr/share/libexttextcat/frp.lm
   /usr/share/libexttextcat/fur.lm
   /usr/share/libexttextcat/fy.lm
   /usr/share/libexttextcat/ga.lm
@@ -113,7 +113,7 @@ Files included in the binary package:
   /usr/share/libexttextcat/gu.lm
   /usr/share/libexttextcat/gug.lm
   /usr/share/libexttextcat/gv.lm
-  /usr/share/libexttextcat/ha-NG.lm
+  /usr/share/libexttextcat/ha-Latn-NG.lm
   /usr/share/libexttextcat/haw.lm
   /usr/share/libexttextcat/he.lm
   /usr/share/libexttextcat/hi.lm
@@ -130,6 +130,8 @@ Files included in the binary package:
   /usr/share/libexttextcat/it.lm
   /usr/share/libexttextcat/ja.lm
   /usr/share/libexttextcat/ka.lm
+  /usr/share/libexttextcat/kaa.lm
+  /usr/share/libexttextcat/kab.lm
   /usr/share/libexttextcat/kbd.lm
   /usr/share/libexttextcat/kk.lm
   /usr/share/libexttextcat/kl.lm
@@ -150,6 +152,7 @@ Files included in the binary package:
   /usr/share/libexttextcat/lt.lm
   /usr/share/libexttextcat/lv.lm
   /usr/share/libexttextcat/mai.lm
+  /usr/share/libexttextcat/mfe.lm
   /usr/share/libexttextcat/mi.lm
   /usr/share/libexttextcat/min.lm
   /usr/share/libexttextcat/mk.lm
@@ -177,6 +180,7 @@ Files included in the binary package:
   /usr/share/libexttextcat/plt.lm
   /usr/share/libexttextcat/pt.lm
   /usr/share/libexttextcat/quh.lm
+  /usr/share/libexttextcat/qul.lm
   /usr/share/libexttextcat/quz.lm
   /usr/share/libexttextcat/rm.lm
   /usr/share/libexttextcat/ro.lm
@@ -191,9 +195,12 @@ Files included in the binary package:
   /usr/share/libexttextcat/sg.lm
   /usr/share/libexttextcat/shs.lm
   /usr/share/libexttextcat/si.lm
+  /usr/share/libexttextcat/sid.lm
   /usr/share/libexttextcat/sk.lm
   /usr/share/libexttextcat/skr.lm
   /usr/share/libexttextcat/sl.lm
+  /usr/share/libexttextcat/smn.lm
+  /usr/share/libexttextcat/sms.lm
   /usr/share/libexttextcat/so.lm
   /usr/share/libexttextcat/sq.lm
   /usr/share/libexttextcat/sr-Cyrl.lm
@@ -205,6 +212,7 @@ Files included in the binary package:
   /usr/share/libexttextcat/sw.lm
   /usr/share/libexttextcat/swb.lm
   /usr/share/libexttextcat/ta.lm
+  /usr/share/libexttextcat/te.lm
   /usr/share/libexttextcat/tet.lm
   /usr/share/libexttextcat/tg.lm
   /usr/share/libexttextcat/th.lm
@@ -231,12 +239,13 @@ Files included in the binary package:
   /usr/share/libexttextcat/xh.lm
   /usr/share/libexttextcat/yi.lm
   /usr/share/libexttextcat/yo.lm
+  /usr/share/libexttextcat/yrk.lm
   /usr/share/libexttextcat/zh-Hans.lm
   /usr/share/libexttextcat/zh-Hant.lm
   /usr/share/libexttextcat/zu.lm
 
-(libexttextcat2.0_0)
-  /usr/bin/cygexttextcat-2.0-0.dll
+(libexttextcat2.0_1)
+  /usr/bin/cygexttextcat-2.0-1.dll
 
 (libexttextcat2.0-devel)
   /usr/include/libexttextcat/common.h
@@ -255,6 +264,9 @@ Files included in the binary package:
 ------------------
 
 Port Notes:
+
+----- version 3.4.8-1bl1 -----
+Version bump.
 
 ----- version 3.4.7-1bl2 -----
 Rebuild with gcc-13.4.0

--- a/libexttextcat/libexttextcat-3.4.7-1bl2.src.patch
+++ b/libexttextcat/libexttextcat-3.4.7-1bl2.src.patch
@@ -1,7 +1,0 @@
---- origsrc/libexttextcat-3.4.7/langclass/LM/Makefile.am	2024-01-02 01:14:22.000000000 +0900
-+++ src/libexttextcat-3.4.7/langclass/LM/Makefile.am	2025-08-30 08:46:03.948388800 +0900
-@@ -1,3 +1,3 @@
- EXTRA_DIST = ${wildcard *.lm}
- 
--pkgdata_DATA = ${wildcard *.lm}
-+pkgdata_DATA = $(srcdir)/*.lm

--- a/libexttextcat/libexttextcat-3.4.8-1bl1.cygport
+++ b/libexttextcat/libexttextcat-3.4.8-1bl1.cygport
@@ -20,7 +20,7 @@ DIFF_EXCLUDES="
 
 PKG_NAMES="
 	${PN}
-	${PN}2.0_0
+	${PN}2.0_1
 	${PN}2.0-devel
 	vala-${PN}
 "
@@ -29,8 +29,8 @@ libexttextcat_CONTENTS="
 	usr/share/doc
 	usr/share/${PN}
 "
-libexttextcat2_0_0_CONTENTS="
-	usr/bin/cyg*-0.dll
+libexttextcat2_0_1_CONTENTS="
+	usr/bin/cyg*-1.dll
 "
 libexttextcat2_0_devel_CONTENTS="
 	usr/include
@@ -40,6 +40,6 @@ vala_libexttextcat_CONTENTS="
 	usr/share/vala
 "
 libexttextcat_SUMMARY="${SUMMARY} (utilities)"
-libexttextcat2_0_0_SUMMARY="${SUMMARY} (runtime)"
+libexttextcat2_0_1_SUMMARY="${SUMMARY} (runtime)"
 libexttextcat2_0_devel_SUMMARY="${SUMMARY} (development)"
 vala_libexttextcat_SUMMARY="${SUMMARY} (vala bindings)"

--- a/libexttextcat/libexttextcat-3.4.8-1bl1.src.patch
+++ b/libexttextcat/libexttextcat-3.4.8-1bl1.src.patch
@@ -1,0 +1,7 @@
+--- origsrc/libexttextcat-3.4.8/langclass/LM/Makefile.am	2026-05-16 10:35:57.000000000 +0000
++++ src/libexttextcat-3.4.8/langclass/LM/Makefile.am	2026-08-25 13:20:23.455957600 +0000
+@@ -1,3 +1,3 @@
+ EXTRA_DIST = ${wildcard *.lm}
+ 
+-pkgdata_DATA = ${wildcard *.lm}
++pkgdata_DATA = $(srcdir)/*.lm


### PR DESCRIPTION
Version `3.4.8`, built and validated by [dorgann](https://github.com/fd00/dorgann).

Run: https://github.com/fd00/dorgann/actions/runs/32682285081

<!-- dorgann-meta: {"artifact_id":"9565048276"} -->

To publish this build to gh-pages:
```
gh workflow run publish.yml -f artifact_id=9565048276 --repo fd00/dorgann
```